### PR TITLE
Fix default trigger value in SUMP mode

### DIFF
--- a/components/logic_analyzer/logic_analyzer_sump/logic_analyzer_sump.c
+++ b/components/logic_analyzer/logic_analyzer_sump/logic_analyzer_sump.c
@@ -20,7 +20,10 @@
 #include "logic_analyzer_sump.h"
 #include "logic_analyzer_serial.h"
 
-static int first_trigger_pin = 0;
+// No trigger configured by default. PulseView will update this via
+// SUMP_TRIGGER_MASK_CH_A command. Using 0 as default results in an
+// unintended trigger on the first channel when no trigger is set.
+static int first_trigger_pin = -1;
 static int first_trigger_val = 0;
 static int divider = 0;
 static int readCount = 0;


### PR DESCRIPTION
## Summary
- disable trigger by default in SUMP mode

## Testing
- `cmake .` *(fails: include could not find requested file /tools/cmake/project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_6867fafd2b7c8328824eea889da058b0